### PR TITLE
Rename dsmc logs

### DIFF
--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -89,6 +89,24 @@ class BaseDsmcHandler(BaseRestHandler):
             log.info("Removing empty folder: {}".format(path))
             os.rmdir(path)
 
+    @staticmethod
+    def _rename_log_file(log_file):
+        """
+        Add timestamp to existing log-files when the same archive i uploaded or reuploaded several times
+
+        :param log_file:/home/monika/git_workspace/snpseq-archive-upload/tests/resources/archives/test_logs/dsmc_monika_archive
+        :return output_file-name
+        """
+        output_file = "{}/dsmc_output".format(log_file)
+
+        if os.path.isfile(output_file):
+            #add a timestamp if the file dsmc_ouput already exist for the given archive.
+            timestamp = os.path.getmtime(output_file)
+            timestamp_filename = "{}/dsmc_output.{}".format(log_file, timestamp)
+            os.rename(output_file, timestamp_filename)
+
+        return output_file
+
     def write_error(self, status_code, **kwargs):
         self.set_header("Content-Type", "application/json")
         response_data = {
@@ -311,7 +329,7 @@ class ReuploadHelper(object):
 
         log.debug("Written files to reupload to {}".format(reupload_file))
 
-        output_file = "{}/dsmc_output".format(dsmc_log_dir)
+        output_file = self._rename_log_file(dsmc_log_dir)
 
         cmd = "export DSM_LOG={} && dsmc archive -filelist={} -description={}".format(
             dsmc_log_dir, reupload_file, descr)
@@ -444,7 +462,8 @@ class UploadHandler(BaseDsmcHandler):
         if not os.path.exists(dsmc_log_dir):
             os.makedirs(dsmc_log_dir)
 
-        output_file = "{}/dsmc_output".format(dsmc_log_dir)
+
+        output_file = self._rename_log_file(dsmc_log_dir)
 
         log.info("Uploading {} to PDC...".format(path_to_archive))
         cmd = "export DSM_LOG={} && dsmc archive {}/ -subdir=yes -description={}".format(

--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -329,7 +329,7 @@ class ReuploadHelper(object):
 
         log.debug("Written files to reupload to {}".format(reupload_file))
 
-        output_file = self._rename_log_file(dsmc_log_dir)
+        output_file = BaseDsmcHandler._rename_log_file(dsmc_log_dir)
 
         cmd = "export DSM_LOG={} && dsmc archive -filelist={} -description={}".format(
             dsmc_log_dir, reupload_file, descr)

--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -90,19 +90,19 @@ class BaseDsmcHandler(BaseRestHandler):
             os.rmdir(path)
 
     @staticmethod
-    def _rename_log_file(log_file):
+    def _rename_log_file(log_dir):
         """
         Add timestamp to existing log-files when the same archive i uploaded or reuploaded several times
 
         :param log_file:/home/monika/git_workspace/snpseq-archive-upload/tests/resources/archives/test_logs/dsmc_monika_archive
         :return output_file-name
         """
-        output_file = "{}/dsmc_output".format(log_file)
+        output_file = "{}/dsmc_output".format(log_dir)
 
         if os.path.isfile(output_file):
             #add a timestamp if the file dsmc_ouput already exist for the given archive.
             timestamp = os.path.getmtime(output_file)
-            timestamp_filename = "{}/dsmc_output.{}".format(log_file, timestamp)
+            timestamp_filename = "{}/dsmc_output.{}".format(log_dir, timestamp)
             os.rename(output_file, timestamp_filename)
 
         return output_file

--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -92,17 +92,17 @@ class BaseDsmcHandler(BaseRestHandler):
     @staticmethod
     def _rename_log_file(log_dir):
         """
-        Add timestamp to existing log-files when the same archive i uploaded or reuploaded several times
+        Add timestamp to existing log-files when the same archive is uploaded or reuploaded several times
 
-        :param log_file:/home/monika/git_workspace/snpseq-archive-upload/tests/resources/archives/test_logs/dsmc_monika_archive
+        :param log_dir:/path/to/log-directory/dsmc_<archive name>
         :return output_file-name
         """
-        output_file = "{}/dsmc_output".format(log_dir)
+        output_file = os.path.join(log_dir, "dsmc_output")
 
         if os.path.isfile(output_file):
             #add a timestamp if the file dsmc_ouput already exist for the given archive.
             timestamp = os.path.getmtime(output_file)
-            timestamp_filename = "{}/dsmc_output.{}".format(log_dir, timestamp)
+            timestamp_filename = "{}.{}".format(output_file, timestamp)
             os.rename(output_file, timestamp_filename)
 
         return output_file

--- a/tests/test_dsmc_handlers.py
+++ b/tests/test_dsmc_handlers.py
@@ -509,11 +509,11 @@ echo uggla
             shutil.rmtree(archive_path)
             TestUtils.DUMMY_CONFIG = local_config
 
-    @mock.patch("archive_upload.handlers.dsmc_handlers.os.path", autospec=True)
-    def test_rename_log_file_no_file(self, mock_path):
+    @mock.patch("archive_upload.handlers.dsmc_handlers.os.path.isfile", autospec=True)
+    def test_rename_log_file_no_file(self, mock_isfile):
         log_directory = "/log/directory/name_archive"
         expected_log_name = "/log/directory/name_archive/dsmc_output"
-        mock_path.isfile.return_value = False
+        mock_isfile.return_value = False
         self.assertEqual(BaseDsmcHandler._rename_log_file(log_directory), expected_log_name)
 
     def test_rename_log_file_exist(self):

--- a/tests/test_dsmc_handlers.py
+++ b/tests/test_dsmc_handlers.py
@@ -508,3 +508,22 @@ echo uggla
         finally:
             shutil.rmtree(archive_path)
             TestUtils.DUMMY_CONFIG = local_config
+
+    @mock.patch("archive_upload.handlers.dsmc_handlers.os.path", autospec=True)
+    def test_rename_log_file_no_file(self, mock_path):
+        log_directory = "/log/directory/name_archive"
+        expected_log_name = "/log/directory/name_archive/dsmc_output"
+        mock_path.isfile.return_value = False
+        self.assertEqual(BaseDsmcHandler._rename_log_file(log_directory), expected_log_name)
+
+    def test_rename_log_file_exist(self):
+        with mock.patch('archive_upload.handlers.dsmc_handlers.os.rename') as mock_rename, \
+                mock.patch('archive_upload.handlers.dsmc_handlers.os.path.isfile') as mock_isfile, \
+                mock.patch('archive_upload.handlers.dsmc_handlers.os.path.getmtime') as mock_getmtime:
+         mock_isfile.return_value = True
+         log_directory = "/log/directory/name_archive"
+         expected_log_name = "/log/directory/name_archive/dsmc_output"
+         mock_getmtime.return_value = "timestamp"
+         self.assertEqual(BaseDsmcHandler._rename_log_file(log_directory), expected_log_name)
+         mock_rename.assert_called_once_with("/log/directory/name_archive/dsmc_output",
+                                                "/log/directory/name_archive/dsmc_output.timestamp")


### PR DESCRIPTION
**What problems does this PR solve?**
When snpseq-archive-upload/reupload is called for an archive that has already been uploaded to PDC new output is added to the log-file dsmc_output. This is the log-file that we later parse to find errors to be compared to the whitelist. However, old errors will still be in the log when the service is called and this can cause "false" failure. To prevent this a new log-file is created every time the service is called.
 
**How has the changes been tested?**
Unit testing.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
