### PR TITLE
DEVELOP-932 - exclude dirs and extensions are now accepted as a comma…

### DIFF
--- a/tests/test_dsmc_handlers.py
+++ b/tests/test_dsmc_handlers.py
@@ -139,7 +139,7 @@ class TestDsmcHandlers(AsyncHTTPTestCase):
         self.assertTrue(os.path.exists(os.path.join(archive_path, "directory2", "file.bin")))
 
         # Exclude parameters in POST request
-        body = {"remove": "True", "exclude_dirs": ["directory3"], "exclude_extensions": [".bin"]}
+        body = {"remove": "True", "exclude_dirs": "directory3, someotherdir", "exclude_extensions": ".bin,.hmm"}
         response = self.fetch(self.API_BASE + "/create_dir/testrunfolder", method="POST", body=json_encode(body))
         json_resp = json.loads(response.body)
 


### PR DESCRIPTION
… separated string instead of lists. This makes it easier to send data from Stackstorm.

**What problems does this PR solve?**
Continuation of previous PR for DEVELOP-932

**How has the changes been tested?**
- automated tests
- manual testing of service locally
- service invoked through Stackstorm

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
