### PR TITLE
DEVELOP-932 - remove support for reading dir and extension exclusion …

### DIFF
--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -653,10 +653,8 @@ class CreateDirHandler(BaseDsmcHandler):
         path_to_archive_root = self.config["path_to_archive_root"]
         path_to_archive = os.path.abspath(
             os.path.join(path_to_archive_root, runfolder) + "_archive")
-
-        # Default values come from config file but can be overridden in the POST request.
-        exclude_dirs = self.config["exclude_dirs"]
-        exclude_extensions = self.config["exclude_extensions"]
+        exclude_dirs = []
+        exclude_extensions = []
 
         # Messages
         invalid_body_msg = "Invalid body format."
@@ -672,8 +670,10 @@ class CreateDirHandler(BaseDsmcHandler):
         remove = False
         if "remove" in request_data:
             remove = request_data["remove"]
-            # Booleans may arrive in either in JSON format (true)
-            # or stringified Python format ("True") (e.g. from the Irma archiving workflow)
+            # Booleans may arrive in either in:
+            # 1) JSON format (true), or
+            # 2) stringified Python format ("True") (e.g. from the Irma archiving workflow)
+            # TODO: Remove support for format 2, see DEVELOP-1024 // ML, 2021-01
             try:
                 if not isinstance(remove, bool):
                     remove = eval(request_data["remove"])

--- a/config/app.config
+++ b/config/app.config
@@ -25,11 +25,5 @@ log_directory: /tmp/archive-upload/
 # See full list at e.g. https://www.ibm.com/support/knowledgecenter/en/SSGSG7_7.1.1/com.ibm.itsm.msgs.client.doc/msgs_client_list_intro.html
 whitelisted_warnings: ["ANS1809W", "ANS2042W", "ANS2250W"]
 
-# Exclude filters (different on biotank and Irma)
-#
-# Dirs and file extensions to exclude from the _archive copy of the runfolder/project
-exclude_dirs: ["Data", "Thumbnail_Images"]
-exclude_extensions: [".bcl"]
-
-# Elements to exclude from the tarball of the _archive dir
+# Elements to exclude from the tarball of the _archive dir (different on biotank and Irma)
 exclude_from_tarball: ["Config", "InterOp", "SampleSheet.csv", "Unaligned", "runParameters.xml", "RunInfo.xml"]

--- a/tests/test_dsmc_handlers.py
+++ b/tests/test_dsmc_handlers.py
@@ -131,11 +131,12 @@ class TestDsmcHandlers(AsyncHTTPTestCase):
         import time
         time.sleep(1)
 
+        # Ensure nothing is excluded
         self.assertEqual(json_resp["state"], State.DONE)
         self.assertTrue(os.path.exists(archive_path))
-        # directory1 and *.bar are excluded in the config file
-        self.assertFalse(os.path.exists(os.path.join(archive_path, "directory1")))
-        self.assertFalse(os.path.exists(os.path.join(archive_path, "directory2", "file.bar")))
+        self.assertTrue(os.path.exists(os.path.join(archive_path, "directory1")))
+        self.assertTrue(os.path.exists(os.path.join(archive_path, "directory3")))
+        self.assertTrue(os.path.exists(os.path.join(archive_path, "directory2", "file.bar")))
         self.assertTrue(os.path.exists(os.path.join(archive_path, "directory2", "file.bin")))
 
         # Exclude parameters in POST request
@@ -143,11 +144,10 @@ class TestDsmcHandlers(AsyncHTTPTestCase):
         response = self.fetch(self.API_BASE + "/create_dir/testrunfolder", method="POST", body=json_encode(body))
         json_resp = json.loads(response.body)
 
+        # Ensure that only extensions and dirs in the POST request are excluded
         self.assertEqual(json_resp["state"], State.DONE)
-        # Ensure that extensions and dirs in config file are no longer excluded
         self.assertTrue(os.path.exists(os.path.join(archive_path, "directory1")))
         self.assertTrue(os.path.exists(os.path.join(archive_path, "directory2", "file.bar")))
-        # Ensure that extensions and dirs in the POST request are excluded
         self.assertFalse(os.path.exists(os.path.join(archive_path, "directory3")))
         self.assertFalse(os.path.exists(os.path.join(archive_path, "directory2", "file.bin")))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,9 +6,7 @@ class TestUtils:
         "whitelisted_warnings": ["ANS1809W", "ANS2000W"], 
         "log_directory": "tests/resources/dsmc_output/", 
         "path_to_archive_root": "tests/resources/archives/",
-        "exclude_from_tarball": ["Config", "SampleSheet.csv", "file.csv", "directory3"], 
-        "exclude_dirs": ["directory1"],
-        "exclude_extensions": [".bar"]
+        "exclude_from_tarball": ["Config", "SampleSheet.csv", "file.csv", "directory3"]
     }
 
 class DummyConfig:


### PR DESCRIPTION
**What problems does this PR solve?**

- Removes support for reading dir and extension exclusion variables from config file. These are now determined by parameters from the POST request only

**How has the changes been tested?**

- automatic tests
- POSTing from a test client
- POSTing from a heavily modified ngi_uu_workflow on a local instance of snpseq packs

**Reasons for careful code review**

This fundamentally changes exclusion behavior. These changes should be released in tandem with the corresponding snpseq_packs changes.
