### PR TITLE
DEVELOP-932 - make remove field optional in create_dir

### DIFF
--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -658,7 +658,7 @@ class CreateDirHandler(BaseDsmcHandler):
 
         # Messages
         invalid_body_msg = "Invalid body format."
-        missing_rm_msg = "Need to provide a boolean for the `remove` field in the HTTP body."
+        missing_rm_msg = "The `remove` field must be a boolean."
         exclude_dirs_msg = "The `exclude_dirs` field must be a comma-separated string."
         exclude_extensions_msg = "The `exclude_extensions` field must be a comma-separated string."
 
@@ -679,8 +679,6 @@ class CreateDirHandler(BaseDsmcHandler):
                     remove = eval(request_data["remove"])
             except (NameError):
                 raise ArchiveException(reason=missing_rm_msg, status_code=400)
-        else:
-            raise ArchiveException(reason=missing_rm_msg, status_code=400)
 
         if "exclude_dirs" in request_data:
             exclude_dirs = request_data["exclude_dirs"]

--- a/tests/test_dsmc_handlers.py
+++ b/tests/test_dsmc_handlers.py
@@ -158,6 +158,13 @@ class TestDsmcHandlers(AsyncHTTPTestCase):
 
         self.assertEqual(json_resp["state"], State.ERROR)
 
+        # Should fail due to folder already existing (default is remove: false)
+        body = {}
+        response = self.fetch(self.API_BASE + "/create_dir/testrunfolder", method="POST", body=json_encode(body))
+        json_resp = json.loads(response.body)
+
+        self.assertEqual(json_resp["state"], State.ERROR)
+
         # Check that the dir is recreated
         os.mkdir(os.path.join(archive_path, "remove-me"))
 
@@ -173,7 +180,7 @@ class TestDsmcHandlers(AsyncHTTPTestCase):
         shutil.rmtree(archive_path)
 
     def test_create_dir_on_biotank(self):
-        body = {"remove": "False"}
+        body = {}
         header = {"Host": "biotank42"}
         root = self.dummy_config["monitored_directory"]
         runfolder = "testrunfolder"
@@ -194,8 +201,8 @@ class TestDsmcHandlers(AsyncHTTPTestCase):
         json_resp = json.loads(resp.body)
         self.assertEqual(json_resp["state"], State.ERROR)
 
-    def test_create_dir_missing_remove(self):
-        body = {"foo": "bar"}
+    def test_create_dir_invalid_remove(self):
+        body = {"remove": "foobar"}
         resp = self.fetch(self.API_BASE + "/create_dir/testrunfolder", method="POST", body=json_encode(body))
         self.assertEqual(resp.code, 400)
         json_resp = json.loads(resp.body)


### PR DESCRIPTION
Default is false, so this should not cause any unexpected behaviors.

**What problems does this PR solve?**
Allows workflows to make POST requests to create_dir without specifying a "remove" value. (Our dict to json parser in snpseq_packs removes all falsey values.)

**How has the changes been tested?**
Automatic tests updated; manual testing using Postman confirmed that omitting the "remove" value from the POST request causes the same behavior as setting it to false. Non-boolean values should still cause an error.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [x] Just make sure the default is indeed false!
