### PR TITLE
DEVELOP-1206 - required_dirs is now a configurable variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Trying it out
 
 And then you can find a simple api documentation with:
 
-    curl http://localhost:8181/api
+    curl http://localhost:8333/api
 
 To run the tests:
 


### PR DESCRIPTION
**What problems does this PR solve?**
This PR removes the hardcoded requirement that all archiving from biotanks must validate the presence of an Unaligned folder. This enables us to archive Olink folders, which do not have this subfolder. Instead, the service now accepts a required_dirs parameter.

This PR will be paired with another PR to snpseq_packs that will send these variables.

**How has the changes been tested?**
Automatic tests plus local testing using Postman client.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [x] This PR contains code that could remove data
