### PR TITLE
DEVELOP-1206 - add Data dir to tarball exclusions

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -26,4 +26,4 @@ log_directory: /tmp/archive-upload/
 whitelisted_warnings: ["ANS1809W", "ANS2042W", "ANS2250W"]
 
 # Elements to exclude from the tarball of the _archive dir (different on biotank and Irma)
-exclude_from_tarball: ["Config", "InterOp", "SampleSheet.csv", "Unaligned", "runParameters.xml", "RunInfo.xml"]
+exclude_from_tarball: ["Config", "Data", "InterOp", "SampleSheet.csv", "Unaligned", "runParameters.xml", "RunInfo.xml"]


### PR DESCRIPTION
**What problems does this PR solve?**
This PR adds the Data dir to the list of paths excluded from tarball creation.
This change is done for documentation purposes only, as production systems actually read the change from a copy of app.config that lives in the system-management repo.

**How has the changes been tested?**
n/a. Automated tests all pass.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
