### PR TITLE
DEVELOP-1408 - enable mocking of tsm client

### DIFF
--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -471,9 +471,14 @@ class UploadHandler(BaseDsmcHandler):
             dsmc_log_dir, path_to_archive, uniq_id)
 
         # Mock starting the TSM process if mock mode is enabled
-        tsm_mock_enabled = self.config.__getitem__("tsm_mock_enabled")
+        try:
+            tsm_mock_enabled = self.config["tsm_mock_enabled"]
+        except KeyError:
+            tsm_mock_enabled = False
         if tsm_mock_enabled:
             self.runner_service.start = Mock(return_value=self.config["tsm_mock_job_id"])
+            log.warning("Running TSM client on mock mode for archive: {}, job: {}".format(
+                runfolder_archive, self.config["tsm_mock_job_id"]))
 
         job_id = self.runner_service.start(
             cmd, nbr_of_cores=1, run_dir=dsmc_log_dir, stdout=output_file, stderr=output_file)
@@ -822,7 +827,11 @@ class StatusHandler(BaseDsmcHandler):
         """
 
         if job_id:
-            if self.config.__getitem__("tsm_mock_enabled"):
+            try:
+                tsm_mock_enabled = self.config["tsm_mock_enabled"]
+            except KeyError:
+                tsm_mock_enabled = False
+            if tsm_mock_enabled:
                 self.runner_service.status = Mock(return_value=self.config["tsm_mock_status"])
             status = {"state": self.runner_service.status(job_id)}
         else:

--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -488,6 +488,10 @@ class UploadHandler(BaseDsmcHandler):
             self.request.host,
             self.reverse_url("status", job_id))
 
+        message = ""
+        if tsm_mock_enabled:
+            message = "tsm_mock_enabled"
+
         response_data = {
             "job_id": job_id,
             "service_version": version,
@@ -496,10 +500,10 @@ class UploadHandler(BaseDsmcHandler):
             "dsmc_log_dir": dsmc_log_dir,
             "archive_path": path_to_archive,
             "archive_description": uniq_id,
-            "archive_host": socket.gethostname() }
+            "archive_host": socket.gethostname(),
+            "message": message }
 
-        if tsm_mock_enabled:
-            response_data["tsm_mock_enabled"] = tsm_mock_enabled
+
 
         self.set_status(202, reason="started processing")
         self.write_object(response_data)

--- a/config/app.config
+++ b/config/app.config
@@ -27,3 +27,9 @@ whitelisted_warnings: ["ANS1809W", "ANS2042W", "ANS2250W"]
 
 # Elements to exclude from the tarball of the _archive dir (different on biotank and Irma)
 exclude_from_tarball: ["Config", "Data", "InterOp", "SampleSheet.csv", "Unaligned", "runParameters.xml", "RunInfo.xml"]
+
+# Toggle TSM mocking. NB: This should always be False in production!
+# Status can be changed to anything in arteria-core#State: https://github.com/arteria-project/arteria-core/blob/master/arteria/web/state.py
+tsm_mock_enabled: False
+tsm_mock_job_id: 999
+tsm_mock_status: "done"

--- a/requirements/dev
+++ b/requirements/dev
@@ -1,4 +1,3 @@
 -r prod
-mock==1.0.1
 nose==1.3.7
 mockproc==0.3.1

--- a/requirements/prod
+++ b/requirements/prod
@@ -4,4 +4,4 @@ git+https://github.com/dakl/localq.git@v0.3.7
 # Localq depence on networkx
 networkx==1.11
 arteria==1.1.3
-
+mock==1.0.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,8 @@ class TestUtils:
         "whitelisted_warnings": ["ANS1809W", "ANS2000W"], 
         "log_directory": "tests/resources/dsmc_output/", 
         "path_to_archive_root": "tests/resources/archives/",
-        "exclude_from_tarball": ["Config", "SampleSheet.csv", "file.csv", "directory3"]
+        "exclude_from_tarball": ["Config", "SampleSheet.csv", "file.csv", "directory3"],
+        "tsm_mock_enabled": False
     }
 
 class DummyConfig:


### PR DESCRIPTION
**What problems does this PR solve?**
We recently had some issues connecting to PDC with the TSM client on staging. As a result, we had to release untested changes and test them directly in production. This PR will prevent this in the future by allowing us to mock calls to TSM if mock mode is enabled.

**How has the changes been tested?**
Automated tests, manual testing on local instance with mock mode both enabled and disabled.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
