### PR TITLE
Upload from miarka

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Run Unit Tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e . -r ./requirements/dev
+    - name: Launch tests
+      run: |
+        nosetests ./tests

--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -369,8 +369,8 @@ class ReuploadHelper(object):
 
         :return: a string with arguments that should be appended to the dsmc command line
         """
-        args = [f"-{k}='{v}'" for k, v in key_values.items() if v is not None]
-        args.extend([f"-{k}" for k, v in key_values.items() if v is None])
+        args = ["-{}='{}'".format(k, v) for k, v in key_values.items() if v is not None]
+        args.extend(["-{}".format(k) for k, v in key_values.items() if v is None])
         return " ".join(args)
 
 
@@ -491,6 +491,7 @@ class UploadHandler(BaseDsmcHandler):
 
         path_to_archive = os.path.join(monitored_dir, runfolder_archive)
         dsmc_log_root_dir = self.config["log_directory"]
+        dsmc_extra_args = self.config.get("dsmc_extra_args", "")
         uniq_id = str(uuid.uuid4())
 
         if not self._is_valid_log_dir(dsmc_log_root_dir):

--- a/archive_upload/handlers/dsmc_handlers.py
+++ b/archive_upload/handlers/dsmc_handlers.py
@@ -39,7 +39,7 @@ class BaseDsmcHandler(BaseRestHandler):
         :param config: configuration used by the service
         :param runner_service: runner service to use. Must fulfill `archive_upload.lib.jobrunner.JobRunnerAdapter` interface
         """
-        self.config = config
+        self.config = config.get_app_config()
         self.runner_service = runner_service
 
     @staticmethod
@@ -402,7 +402,7 @@ class ReuploadHandler(BaseDsmcHandler):
 
         path_to_archive = os.path.join(monitored_dir, runfolder_archive)
         dsmc_log_root_dir = self.config["log_directory"]
-        dsmc_extra_args = self.config.get("dsmc_extra_args", "")
+        dsmc_extra_args = self.config.get("dsmc_extra_args", {})
 
         if not self._is_valid_log_dir(dsmc_log_root_dir):
             msg = "Error when validating log dir. {} is not a directory.".format(dsmc_log_root_dir)
@@ -491,7 +491,7 @@ class UploadHandler(BaseDsmcHandler):
 
         path_to_archive = os.path.join(monitored_dir, runfolder_archive)
         dsmc_log_root_dir = self.config["log_directory"]
-        dsmc_extra_args = self.config.get("dsmc_extra_args", "")
+        dsmc_extra_args = self.config.get("dsmc_extra_args", {})
         uniq_id = str(uuid.uuid4())
 
         if not self._is_valid_log_dir(dsmc_log_root_dir):
@@ -781,6 +781,58 @@ class CompressArchiveHandler(BaseDsmcHandler):
     Handler for compressing certain files in the archive before uploading.
     """
 
+    @staticmethod
+    def _create_tarball_cmd(tarball_name, path_to_archive, exclude_from_tarball):
+        exclude_patterns = " ".join(
+            [
+                "--exclude={}".format(p)
+                for p in exclude_from_tarball + [tarball_name]
+            ]
+        )
+        return "cd {} && " \
+               "touch {} && " \
+               "tar " \
+               "--create " \
+               "--gzip " \
+               "--dereference " \
+               "--hard-dereference " \
+               "--file={} " \
+               "{} " \
+               ".".format(
+            path_to_archive,
+            tarball_name,
+            tarball_name,
+            exclude_patterns
+        )
+
+    @staticmethod
+    def _remove_tarballed_files_cmd(path_to_archive, tarball_name):
+        return "cd {} && " \
+               "tar " \
+               "--list " \
+               "--file={} |" \
+               "xargs " \
+               "-n1 " \
+               "rm -f".format(
+            path_to_archive,
+            tarball_name
+        )
+
+    @staticmethod
+    def _remove_empty_dirs_cmd(path_to_archive):
+        return "cd {} && " \
+               "find " \
+               ". " \
+               "-depth " \
+               "-mindepth 1 " \
+               "-type d |" \
+               "xargs " \
+               "-n1 " \
+               "rmdir " \
+               "--ignore-fail-on-non-empty".format(
+            path_to_archive
+        )
+
     def post(self, archive):
         """
         Create a gziped tarball of most files in the archive, with the exception of
@@ -799,7 +851,8 @@ class CompressArchiveHandler(BaseDsmcHandler):
                 archive, path_to_archive_root)
             raise ArchiveException(reason=msg, status_code=400)
 
-        tarball_path = "{}.tar.gz".format(os.path.join(path_to_archive, archive))
+        tarball_name = "{}.tar.gz".format(archive)
+        tarball_path = os.path.join(path_to_archive, tarball_name)
 
         log.debug("Checking to see if {} exists".format(tarball_path))
 
@@ -807,59 +860,50 @@ class CompressArchiveHandler(BaseDsmcHandler):
             msg = "Error when creating archive tarball. {} already exists.".format(tarball_path)
             raise ArchiveException(reason=msg, status_code=400)
 
-        def exclude_content(tarinfo):
-            """
-            Filter function when creating the tarball
-            """
-            name = os.path.basename(tarinfo.name)
-            # The name field contains the path to the file relative to the
-            # root dir of the archive, i.e. the path starts with "./".
-            # Therefore the second element in the list split on "/"
-            # will be the first subdir (if any) inside the archive.
-            first_dir = tarinfo.name.split("/")[1]
-
-            # Don't include the file if it matches our list of
-            # files to exclude, or if the first dir in its path
-            # matches one of the dir names in our exception list.
-            for exclude in exclude_from_tarball:
-                if exclude == name or exclude == first_dir:
-                    return None
-
-            return tarinfo
-
         exclude_from_tarball = self.config["exclude_from_tarball"]
-        log.info("Creating tarball {}...".format(tarball_path))
+        cmd = " ( {} ) && ( {} ) ; ( {} )".format(
+            self._create_tarball_cmd(
+                tarball_name,
+                path_to_archive,
+                exclude_from_tarball),
+            self._remove_tarballed_files_cmd(
+                path_to_archive,
+                tarball_name),
+            self._remove_empty_dirs_cmd(
+                path_to_archive)
+        )
 
-        with tarfile.open(name=tarball_path, mode="w:gz", dereference=True) as tar:
-            tar.add(path_to_archive, arcname="./", recursive=True, filter=exclude_content)
+        log.info("run command: {}".format(cmd))
+        log.info(
+            "Creating tarball {}, then removing files from {} that were added to tarball".format(
+                tarball_path,
+                path_to_archive_root))
 
-        log.info("Removing files from {} that were added to {}".format(
-            path_to_archive_root, tarball_path))
+        log_dir = os.path.abspath(self.config["log_directory"])
+        tarball_log = os.path.abspath(os.path.join(log_dir, "compress_archive.log"))
 
-        # Remove files that were added to the tarball
+        job_id = self.runner_service.start(
+            cmd,
+            nbr_of_cores=1,
+            run_dir=log_dir,
+            stdout=tarball_log,
+            stderr=tarball_log)
 
-        # get a list of files and folders duplicated between the tarball and the archive
-        paths_to_remove = FileUtils.paths_duplicated_in_tarball(tarball_path, path_to_archive)
+        status_end_point = "{0}://{1}{2}".format(
+            self.request.protocol,
+            self.request.host,
+            self.reverse_url("status", job_id))
 
-        # remove the files first
-        for file_to_remove in filter(os.path.isfile, paths_to_remove):
-            try:
-                os.remove(file_to_remove)
-            except OSError as e:
-                raise ArchiveException(
-                    status_code=500,
-                    reason="Error when creating archive tarball. Could not remove file {}: {}".format(
-                        file_to_remove, e))
+        response_data = {
+            "job_id": job_id,
+            "service_version": version,
+            "link": status_end_point,
+            "state": self.runner_service.status(job_id)}
 
-        # then the directories
-        for dir_to_remove_if_empty in filter(os.path.isdir, paths_to_remove):
-            try:
-                os.rmdir(dir_to_remove_if_empty)
-            except OSError as e:
-                log.debug("directory {} not removed, probably because it is not empty".format(dir_to_remove_if_empty))
-
-        response_data = {"service_version": version, "state": State.DONE}
-        self.set_status(200, reason="Finished creating the tarball")
+        self.set_status(
+            202,
+            reason="started compressing archive"
+        )
         self.write_object(response_data)
 
 

--- a/tests/test_dsmc_handlers.py
+++ b/tests/test_dsmc_handlers.py
@@ -271,7 +271,11 @@ cat tests/resources/dsmc_output/dsmc_descr.txt
 
         with self.scripts:
             archive_path = "/data/mm-xart002/runfolders/johanhe_test_0809_001-AG2UJ_archive"
-            descr = helper.get_pdc_descr(archive_path, dsmc_log_dir="")
+            descr = helper.get_pdc_descr(
+                archive_path,
+                dsmc_log_dir="",
+                dsmc_extra_args={}
+            )
 
         self.assertEqual(descr, "e374bd6b-ab36-4f41-94d3-f4eaea9f30d4")
 
@@ -285,7 +289,11 @@ cat tests/resources/dsmc_output/dsmc_descr.txt
 
         with self.scripts:
             archive_path = "/foo"
-            descr = helper.get_pdc_descr(archive_path, dsmc_log_dir="")
+            descr = helper.get_pdc_descr(
+                archive_path,
+                dsmc_log_dir="",
+                dsmc_extra_args={}
+            )
 
     @raises(ArchiveException)
     def test_get_pdc_descr_no_results(self):
@@ -298,7 +306,11 @@ echo apa
 
         with self.scripts:
             archive_path = "foobar"
-            descr = helper.get_pdc_descr(archive_path, dsmc_log_dir="")
+            descr = helper.get_pdc_descr(
+                archive_path,
+                dsmc_log_dir="",
+                dsmc_extra_args={}
+            )
 
     def test_get_pdc_filelist(self):
         self.scripts = mockprocess.MockProc()
@@ -311,7 +323,12 @@ cat tests/resources/dsmc_output/dsmc_pdc_filelist.txt
 
         with self.scripts:
             archive_path = "/data/mm-xart002/runfolders/johanhe_test_0809_001-AG2UJ_archive"
-            filelist = helper.get_pdc_filelist(archive_path, "e374bd6b-ab36-4f41-94d3-f4eaea9f30d4", dsmc_log_dir="")
+            filelist = helper.get_pdc_filelist(
+                archive_path,
+                "e374bd6b-ab36-4f41-94d3-f4eaea9f30d4",
+                dsmc_log_dir="",
+                dsmc_extra_args={}
+            )
 
         with open("tests/resources/dsmc_output/dsmc_pdc_converted_filelist.txt") as f:
             nr_of_files = 0
@@ -331,7 +348,12 @@ cat tests/resources/dsmc_output/dsmc_pdc_filelist.txt
 
         with self.scripts:
             archive_path = "foo"
-            filelist = helper.get_pdc_filelist(archive_path, "foo-bar", dsmc_log_dir="")
+            filelist = helper.get_pdc_filelist(
+                archive_path,
+                "foo-bar",
+                dsmc_log_dir="",
+                dsmc_extra_args={}
+            )
 
     @raises(ArchiveException)
     def test_get_pdc_filelist_no_result(self):
@@ -343,7 +365,12 @@ echo uggla
 """)
         with self.scripts:
             archive_path = "foo"
-            filelist = helper.get_pdc_filelist(archive_path, "foo-bar", dsmc_log_dir="")
+            filelist = helper.get_pdc_filelist(
+                archive_path,
+                "foo-bar",
+                dsmc_log_dir="",
+                dsmc_extra_args={}
+            )
 
     def test_get_local_filelist(self):
         helper = ReuploadHelper()
@@ -427,7 +454,7 @@ echo uggla
                 ("archive_upload.handlers.dsmc_handlers.ReuploadHelper._tmp_file",\
                 autospec=True) as mock__tmp_file:
             mock__tmp_file.side_effect = my_tmp_file
-            res_id = helper.reupload(reupload_files, descr, dsmc_log_dir, runsrv)
+            res_id = helper.reupload(reupload_files, descr, dsmc_log_dir, {}, runsrv)
 
         self.assertEqual(res_id, exp_id)
         self.assertEqual(runsrv.components[-1], descr)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,3 +14,7 @@ class DummyConfig(dict):
 
     def __init__(self):
         super(DummyConfig, self).__init__(TestUtils.DUMMY_CONFIG)
+
+    @staticmethod
+    def get_app_config():
+        return TestUtils.DUMMY_CONFIG.copy()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ class TestUtils:
         "tsm_mock_enabled": False
     }
 
-class DummyConfig:
-    def __getitem__(self, key):
-        return TestUtils.DUMMY_CONFIG[key]
+class DummyConfig(dict):
 
+    def __init__(self):
+        super(DummyConfig, self).__init__(TestUtils.DUMMY_CONFIG)


### PR DESCRIPTION
**What problems does this PR solve?**

This PR addresses some problems encountered when using the service to archive from Miarka. In short, these changes are:

- Add the possibility to define extra args to pass to the dsmc command in the config
- Use the localq job runner to create the archive (compatible with `poll_status`)
- Use the localq job runner to tarball the archive (compatible with `poll_status`) 
- Adapt the unit tests accordingly
- Set up GitHub workflow for running unit tests

**How has the changes been tested?**

Unit tests. Tested the service within the docker container using the example commands. Will also be validated separately.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [X] This PR contains code that could remove data
  - [X] This PR affects the archiving service. Errors affecting the archiving could lead to loss of data.
